### PR TITLE
Update links to openfusion-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 `gjtk` is a library for working with [GeoJSON](http://geojson.org/).
 
-[![Build Status](https://img.shields.io/travis/dmtucker/gjtk-js.svg)](https://travis-ci.org/dmtucker/gjtk-js)
-[![Test Coverage](https://img.shields.io/coveralls/dmtucker/gjtk-js.svg)](https://coveralls.io/github/dmtucker/gjtk-js)
-[![Dependency Status](https://img.shields.io/david/dmtucker/gjtk-js.svg)](https://david-dm.org/dmtucker/gjtk-js)
+[![Build Status](https://img.shields.io/travis/com/openfusion-dev/gjtk-js.svg)](https://travis-ci.com/openfusion-dev/gjtk-js)
+[![Test Coverage](https://img.shields.io/coveralls/openfusion-dev/gjtk-js.svg)](https://coveralls.io/github/openfusion-dev/gjtk-js)
+[![Dependency Status](https://img.shields.io/david/openfusion-dev/gjtk-js.svg)](https://david-dm.org/openfusion-dev/gjtk-js)
 [![NPM Version](https://img.shields.io/npm/v/gjtk.svg)](https://www.npmjs.com/package/gjtk)
 
 ## Installation

--- a/package.json
+++ b/package.json
@@ -8,18 +8,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/dmtucker/gjtk-js.git"
+    "url": "git://github.com/openfusion-dev/gjtk-js.git"
   },
   "keywords": [
     "geojson",
     "toolkit"
   ],
-  "author": "David Tucker <david.michael.tucker@gmail.com>",
+  "author": "David Tucker <dmtucker@ucsc.edu>",
   "license": "GPL",
   "bugs": {
-    "url": "https://github.com/dmtucker/gjtk-js/issues"
+    "url": "https://github.com/openfusion-dev/gjtk-js/issues"
   },
-  "homepage": "https://github.com/dmtucker/gjtk-js",
+  "homepage": "https://github.com/openfusion-dev/gjtk-js",
   "dependencies": {
     "point-in-polygon": "^1.0.0"
   },


### PR DESCRIPTION
Everything, including Travis CI and Coveralls, should point to openfusion-dev now instead of dmtucker.