### PR TITLE
Add registry-url to the Publication workflow

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: "16"
+        registry-url: "https://registry.npmjs.org"
     - env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       run: npm publish


### PR DESCRIPTION
> Please note that you need to set the `registry-url` to `https://registry.npmjs.org/` in `setup-node` to properly configure your credentials.

https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry